### PR TITLE
Make preview_server_host actually default to "localhost"

### DIFF
--- a/lib/staticmatic/configuration.rb
+++ b/lib/staticmatic/configuration.rb
@@ -10,6 +10,7 @@ module StaticMatic
     
     def initialize
       self.preview_server_port = 3000
+      self.preview_server_host = "localhost"
       self.use_extensions_for_page_links = true
       self.sass_options = {}
       self.haml_options = {}


### PR DESCRIPTION
In the template config/site.rb file it says "Default is localhost", but the default is actually nothing.  Inside the start method in the server.rb file the host defaults to "" since the option is not set:

host = staticmatic.configuration.preview_server_host || ""

On my setup, Ubuntu, having an empty host caused an exception deep in Webrick's code.  When I set the option in my local config/site.rb to be "localhost" the issue was fixed.

Also (in a related note), the how to use page, http://staticmatic.rubyforge.org/how_to_use.html, lists basedir/src/configuration.rb as the place to specify the configuration options, though it's now at: config/site.rb.
